### PR TITLE
Relaxar dependência com o Faraday

### DIFF
--- a/vindi.gemspec
+++ b/vindi.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files        +=  Dir.glob("lib/**/*.rb")
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'faraday', '~> 0.13.1'
+  spec.add_dependency 'faraday', '~> 0.13'
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
A dependência com a gem Faraday está muito restrita do jeito que a gem da Vindi está agora.
É bom relaxar um pouco essa dependência senão fica difícil instalar.

Caso prático: aqui no projeto em que estou trabalhando tenho algumas _gems_ do Google que tem exigências do Faraday `(~> 0.11)`, `(~> 0.12)` e `(~> 0.13)`.